### PR TITLE
Explicitly state Iris sodium-compatibility branch dependency for compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ platforms. If you'd prefer to not use a package manager, you can always grab the
 On Windows, the Oracle JDK/JRE builds should be avoided where possible due to their poor quality. Always prefer using
 the open-source builds from AdoptOpenJDK when possible.
 
-This fork requires a compiled jar of [Iris' Sodium-Compatibility branch](https://github.com/IrisShaders/Iris/tree/sodium-compatibility) to be placed in `$REPOSITORY_NAME/.gradle/loom-cache/1.16.4-projectmapped-net.fabricmc.yarn-1.16.4+build.1-v2/`. Create the folders if they don't already exist.
-
+This fork requires a compiled jar of [Iris' Sodium-Compatibility branch](https://github.com/IrisShaders/Iris/tree/sodium-compatibility) to be built, you can build it by running these commands:
+```
+git clone -b sodium-compatibility https://github.com/IrisShaders/Iris.git
+cd Iris
+./gradlew publishToMavenLocal
+```
 #### Compiling 
 Navigate to the directory you've cloned this repository and launch a build with Gradle using `gradlew build` (Windows)
 or `./gradlew build` (macOS/Linux). If you are not using the Gradle wrapper, simply replace `gradlew` with `gradle`

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ platforms. If you'd prefer to not use a package manager, you can always grab the
 On Windows, the Oracle JDK/JRE builds should be avoided where possible due to their poor quality. Always prefer using
 the open-source builds from AdoptOpenJDK when possible.
 
-#### Compiling
+This fork requires a compiled jar of [Iris' Sodium-Compatibility branch](https://github.com/IrisShaders/Iris/tree/sodium-compatibility) to be placed in `$REPOSITORY_NAME/.gradle/loom-cache/1.16.4-projectmapped-net.fabricmc.yarn-1.16.4+build.1-v2/`. Create the folders if they don't already exist.
 
+#### Compiling 
 Navigate to the directory you've cloned this repository and launch a build with Gradle using `gradlew build` (Windows)
 or `./gradlew build` (macOS/Linux). If you are not using the Gradle wrapper, simply replace `gradlew` with `gradle`
 or the path to it.

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
-    modCompile "net.coderbot.iris:iris:0.1.0"
+    modCompile "net.coderbot.iris:iris:0.1.0-sodium_compatibility"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
-    modCompile "net.coderbot.iris:Iris:0.1.0"
+    modCompile "net.coderbot.iris:iris:0.1.0"
 }
 
 processResources {


### PR DESCRIPTION
replacing #1 as i accidentally nuked the repo for said PR