### PR TITLE
Fix github actions build, remove build artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,5 @@ jobs:
         path: 'iris'
     - name: Iris publishToMavenLocal
       run: cd ./iris && ./gradlew publishToMavenLocal && cd ..
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build artifacts
       run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,10 +12,15 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
+    - name: Fetch iris
+      uses: actions/checkout@v2
+      with:
+        repository: 'IrisShaders/Iris'
+        ref: 'sodium-compatibility'
+        path: 'iris'
+    - name: Iris publishToMavenLocal
+      run: cd ./iris && ./gradlew publishToMavenLocal && cd ..
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
     - name: Build artifacts
       run: ./gradlew build
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: build-artifacts
-        path: build/libs


### PR DESCRIPTION
This makes it work like the main iris repo - it builds successfuly (assuming it can build), but gives no artifacts, and this is an indication of anything being possibly broken. Cherry-picked from #3 but with conflicts resolved and also with the addition of removing build artifacts.