### PR TITLE
Update WorldSlice to vanilla values for Indium and LBG compatibility

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -48,7 +48,7 @@ public class WorldSlice extends ReusableObject implements BlockRenderView, Biome
     private static final int SECTION_BLOCK_COUNT = SECTION_BLOCK_LENGTH * SECTION_BLOCK_LENGTH * SECTION_BLOCK_LENGTH;
 
     // The radius of blocks around the origin chunk that should be copied.
-    private static final int NEIGHBOR_BLOCK_RADIUS = 1;
+    private static final int NEIGHBOR_BLOCK_RADIUS = 2;
 
     // The radius of chunks around the origin chunk that should be copied.
     private static final int NEIGHBOR_CHUNK_RADIUS = MathHelper.roundUpToMultiple(NEIGHBOR_BLOCK_RADIUS, 16) >> 4;


### PR DESCRIPTION
Temporary fix that makes Indium and LBG compatible with Iris by giving LBG more context in rendering. This has been tested in starline and seems to work fine, more information [here](https://github.com/comp500/sodium-fabric/commit/676c91596ead7414ac7f6c5b36676dac7cff8c74).