### PR TITLE
Add ability to have custom tabs in the sodium options GUI

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/CustomOptions.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/CustomOptions.java
@@ -1,0 +1,19 @@
+package me.jellysquid.mods.sodium.client.gui;
+
+import me.jellysquid.mods.sodium.client.gui.options.OptionPage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CustomOptions {
+    private static final List<OptionPage> pages = new ArrayList<>();
+
+    // Should be called in the onInitializeClient method for each mod
+    public static void addPage(OptionPage page) {
+        pages.add(page);
+    }
+
+    public static List<OptionPage> getPages() {
+        return pages;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -47,6 +47,7 @@ public class SodiumOptionsGUI extends Screen {
         this.pages.add(SodiumGameOptionPages.general());
         this.pages.add(SodiumGameOptionPages.quality());
         this.pages.add(SodiumGameOptionPages.advanced());
+        this.pages.addAll(CustomOptions.getPages());
     }
 
     public void setPage(OptionPage page) {


### PR DESCRIPTION
You can add a tab by calling `CustomOptions.addPage()`, providing a sodium `OptionPage` object

It was suggested I open a PR here for this change, so here it is