### PR TITLE
Upload Build Artifacts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,3 +22,8 @@ jobs:
       run: cd ./iris && ./gradlew publishToMavenLocal && cd ..
     - name: Build artifacts
       run: ./gradlew build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: build-artifacts
+        path: build/libs


### PR DESCRIPTION
Changed GitHub Actions to upload Build Artifacts.

Iris itself needs to be compiled by hand, which is (in my opinion) a really good idea to make sure nobody "cracks" it.
But this sodium-fork is pointless without Iris, so people bypassing the Patron requirement isn't really a problem.

And it makes things easier (e.g. getting updates)