### PR TITLE
Quick Shader Packs button in sodium options menu

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumOptionsGUI.java
@@ -6,6 +6,7 @@ import me.jellysquid.mods.sodium.client.gui.options.control.ControlElement;
 import me.jellysquid.mods.sodium.client.gui.options.storage.OptionStorage;
 import me.jellysquid.mods.sodium.client.gui.widgets.FlatButtonWidget;
 import me.jellysquid.mods.sodium.client.util.Dim2i;
+import net.coderbot.iris.gui.screen.ShaderPackScreen;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.Drawable;
 import net.minecraft.client.gui.Element;
@@ -108,6 +109,13 @@ public class SodiumOptionsGUI extends Screen {
 
             this.children.add(button);
         }
+        String shaderPacks = new TranslatableText("options.iris.shaderPackSelection").getString();
+        int shaderWidth = 10 + this.textRenderer.getWidth(shaderPacks); 
+        FlatButtonWidget irisButton = new FlatButtonWidget(new Dim2i(x, y, shaderWidth, 16), shaderPacks, () -> client.openScreen(new ShaderPackScreen(this)));
+
+        x += shaderWidth + 6; // In case someone mixes in here
+
+        this.children.add(irisButton);
     }
 
     private void rebuildGUIOptions() {


### PR DESCRIPTION
Basically does the same as the rest of page buttons, but instead of opening a sodium options page, goes to Iris shader pack selector, in 5 lines.

![screenshot](https://user-images.githubusercontent.com/17107132/120539421-db5b7d80-c3e7-11eb-8c94-4e34a5d9267b.png)
