### PR TITLE
fix: Reload renderer on view distance change automatically

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -37,7 +37,6 @@ public class SodiumGameOptionPages {
                         .setControl(option -> new SliderControl(option, 2, 32, 1, ControlValueFormatter.quantity("Chunks")))
                         .setBinding((options, value) -> options.viewDistance = value, options -> options.viewDistance)
                         .setImpact(OptionImpact.HIGH)
-                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build())
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName("Brightness")

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -46,6 +46,7 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     private final MinecraftClient client;
 
     private ClientWorld world;
+    private int renderDistance;
 
     private double lastCameraX, lastCameraY, lastCameraZ;
     private double lastCameraPitch, lastCameraYaw;
@@ -165,6 +166,10 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
 
         this.useEntityCulling = SodiumClientMod.options().advanced.useEntityCulling;
 
+        if (this.client.options.viewDistance != this.renderDistance) {
+            this.reload();
+        }
+
         Profiler profiler = this.client.getProfiler();
         profiler.push("camera_setup");
 
@@ -245,6 +250,8 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
 
         RenderDevice device = RenderDevice.INSTANCE;
 
+        this.renderDistance = this.client.options.viewDistance;
+
         SodiumGameOptions opts = SodiumClientMod.options();
 
         this.renderPassManager = BlockRenderPassManager.createDefaultMappings();
@@ -260,7 +267,7 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
         this.chunkRenderBackend = createChunkRenderBackend(device, opts, vertexFormat);
         this.chunkRenderBackend.createShaders(device);
 
-        this.chunkRenderManager = new ChunkRenderManager<>(this, this.chunkRenderBackend, this.renderPassManager, this.world, this.client.options.viewDistance);
+        this.chunkRenderManager = new ChunkRenderManager<>(this, this.chunkRenderBackend, this.renderPassManager, this.world, this.renderDistance);
         this.chunkRenderManager.restoreChunks(this.loadedChunkPositions);
     }
 


### PR DESCRIPTION
Allows for F3 hotkeys to work, since they don't go through our video settings screen.
This is kind of a hack, but it's what vanilla does anyways.