### PR TITLE
Make compatible with latest iris github version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modImplementation "net.coderbot.iris_mc1_16_5:iris:1.1.0-pre"
+    modImplementation "net.coderbot.iris_mc1_16_5:iris:1.1.0-pre+rev.5c227f1"
 }
 
 if (project.use_third_party_mods) {


### PR DESCRIPTION
The latest iris version publishes to local maven as 1.1.0-pre+rev.5c227f1 instead of 1.1.0-pre which breaks the build process. just changing build.gradle to use 1.1.0-pre+rev.5c227f1 instead of 1.10-pre fixes the issue