### PR TITLE
Immersive Portals Compatibility part 1

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - source install-jdk.sh --feature 16

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,0 @@
-before_install:
-  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
-  - source install-jdk.sh --feature 16

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -15,6 +15,7 @@ import me.jellysquid.mods.sodium.client.render.pipeline.context.ChunkRenderCache
 import me.jellysquid.mods.sodium.client.util.math.FrustumExtended;
 import me.jellysquid.mods.sodium.client.world.ChunkStatusListener;
 import me.jellysquid.mods.sodium.client.world.ClientChunkManagerExtended;
+import me.jellysquid.mods.sodium.client.world.WorldRendererExtended;
 import me.jellysquid.mods.sodium.common.util.ListUtil;
 import net.coderbot.iris.shadows.ShadowRenderingState;
 import net.minecraft.block.entity.BlockEntity;
@@ -39,8 +40,6 @@ import java.util.SortedSet;
  * Provides an extension to vanilla's {@link WorldRenderer}.
  */
 public class SodiumWorldRenderer implements ChunkStatusListener {
-    private static SodiumWorldRenderer instance;
-
     private final MinecraftClient client;
 
     private ClientWorld world;
@@ -59,29 +58,13 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     private ChunkRenderer chunkRenderer;
 
     /**
-     * Instantiates Sodium's world renderer. This should be called at the time of the world renderer initialization.
-     */
-    public static SodiumWorldRenderer create() {
-        if (instance == null) {
-            instance = new SodiumWorldRenderer(MinecraftClient.getInstance());
-        }
-
-        return instance;
-    }
-
-    /**
-     * @throws IllegalStateException If the renderer has not yet been created
-     * @return The current instance of this type
+     * @return The SodiumWorldRenderer based on the current dimension
      */
     public static SodiumWorldRenderer getInstance() {
-        if (instance == null) {
-            throw new IllegalStateException("Renderer not initialized");
-        }
-
-        return instance;
+        return ((WorldRendererExtended) MinecraftClient.getInstance().worldRenderer).getSodiumWorldRenderer();
     }
 
-    private SodiumWorldRenderer(MinecraftClient client) {
+    public SodiumWorldRenderer(MinecraftClient client) {
         this.client = client;
     }
 

--- a/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.java
@@ -408,4 +408,8 @@ public class SodiumWorldRenderer implements ChunkStatusListener {
     public ChunkRenderer getChunkRenderer() {
         return this.chunkRenderer;
     }
+
+    public void swapRenderingContext(RenderSectionManager.RenderingContext context) {
+        this.renderSectionManager.swapContextWith(context);
+    }
 }

--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldRendererExtended.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldRendererExtended.java
@@ -1,0 +1,7 @@
+package me.jellysquid.mods.sodium.client.world;
+
+import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
+
+public interface WorldRendererExtended {
+    SodiumWorldRenderer getSodiumWorldRenderer();
+}

--- a/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
+++ b/src/main/java/me/jellysquid/mods/sodium/mixin/features/chunk_rendering/MixinWorldRenderer.java
@@ -3,6 +3,7 @@ package me.jellysquid.mods.sodium.mixin.features.chunk_rendering;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import me.jellysquid.mods.sodium.client.gl.device.RenderDevice;
 import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
+import me.jellysquid.mods.sodium.client.world.WorldRendererExtended;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.GameOptions;
 import net.minecraft.client.render.*;
@@ -22,7 +23,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.SortedSet;
 
 @Mixin(WorldRenderer.class)
-public abstract class MixinWorldRenderer {
+public abstract class MixinWorldRenderer implements WorldRendererExtended {
     @Shadow
     @Final
     private BufferBuilderStorage bufferBuilders;
@@ -33,6 +34,11 @@ public abstract class MixinWorldRenderer {
 
     private SodiumWorldRenderer renderer;
 
+    @Override
+    public SodiumWorldRenderer getSodiumWorldRenderer() {
+        return renderer;
+    }
+
     @Redirect(method = "reload()V", at = @At(value = "FIELD", target = "Lnet/minecraft/client/option/GameOptions;viewDistance:I", ordinal = 1))
     private int nullifyBuiltChunkStorage(GameOptions options) {
         // Do not allow any resources to be allocated
@@ -41,7 +47,7 @@ public abstract class MixinWorldRenderer {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void init(MinecraftClient client, BufferBuilderStorage bufferBuilders, CallbackInfo ci) {
-        this.renderer = SodiumWorldRenderer.create();
+        this.renderer = new SodiumWorldRenderer(client);
     }
 
     @Inject(method = "setWorld", at = @At("RETURN"))


### PR DESCRIPTION
* Eliminate the assumption that only one client world exists at the same time
* Add rendering context swapping for RenderSectionManager. Also simplified `swapState` using that.

Clipping and advanced frustum culling does not yet work.