### PR TITLE
Do not queue RenderSections for rebuilds during shadow rendering

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -217,7 +217,7 @@ public class RenderSectionManager implements ChunkStatusListener {
     }
 
     private void schedulePendingUpdates(RenderSection section) {
-        if (section.getPendingUpdate() == null || !this.adjacencyMap.hasNeighbors(section.getChunkX(), section.getChunkZ())) {
+        if (ShadowRenderingState.areShadowsCurrentlyBeingRendered() || section.getPendingUpdate() == null || !this.adjacencyMap.hasNeighbors(section.getChunkX(), section.getChunkZ())) {
             return;
         }
 


### PR DESCRIPTION
This has been causing
"RenderChunk{chunkX=x, chunkY=y, chunkZ=z} changed update type to null 
while in queue for REBUILD, skipping" to be spammed in the logs occasionally when any shader using shadows is being used.