### PR TITLE
Add support for block entity shadow rendering

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/RenderSectionManager.java
@@ -35,6 +35,7 @@ import me.jellysquid.mods.sodium.common.util.DirectionUtil;
 import me.jellysquid.mods.sodium.common.util.collections.FutureQueueDrainingIterator;
 import me.jellysquid.mods.sodium.common.util.collections.QueueDrainingIterator;
 import net.coderbot.iris.Iris;
+import net.coderbot.iris.pipeline.ShadowRenderer;
 import net.coderbot.iris.shadows.ShadowRenderingState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
@@ -169,6 +170,10 @@ public class RenderSectionManager implements ChunkStatusListener {
         this.iterateChunks(camera, frustum, frame, spectator);
 
         this.needsUpdate = false;
+
+        if(ShadowRenderingState.areShadowsCurrentlyBeingRendered()) {
+            ShadowRenderer.visibleBlockEntities = visibleBlockEntities;
+        }
     }
 
     private void setup(Camera camera) {


### PR DESCRIPTION
This is a very simple fix, superseding the last one.
