### PR TITLE
disable Sodium 1.17's shader mixin

### DIFF
--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -53,7 +53,6 @@
     "features.particle.cull.MixinParticleManager",
     "features.particle.fast_render.MixinBillboardParticle",
     "features.render_layer.MixinRenderLayers",
-    "features.shader.MixinShader",
     "features.sky.MixinWorldRenderer",
     "features.texture_tracking.MixinSprite",
     "features.texture_tracking.MixinSpriteAnimation",


### PR DESCRIPTION
This fixes issues that may be encountered when using a very large number of mods (https://github.com/IrisShaders/Iris/issues/619). This could be implemented better - for example, if Iris detects it's loading alongside Sodium, it could automatically disable Sodium's shader mixin. As of right now, however, this works fine enough, with no noticeable side effects in my testing.