### PR TITLE
Support geometry shaders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.6-SNAPSHOT'
+    id 'fabric-loom' version '0.7-SNAPSHOT'
     id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
@@ -21,7 +21,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-    modImplementation "net.coderbot.iris_mc1_16_5:iris:1.1.1-pre+"
+    modImplementation "net.coderbot.iris_mc1_16_5:iris:1.1.2-pre+"
 }
 
 if (project.use_third_party_mods) {

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/GlProgram.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/GlProgram.java
@@ -72,7 +72,9 @@ public abstract class GlProgram extends GlObject {
         }
 
         public Builder attachShader(GlShader shader) {
-            GL20C.glAttachShader(this.program, shader.handle());
+            if (shader != null) {
+                GL20C.glAttachShader(this.program, shader.handle());
+            }
 
             return this;
         }

--- a/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/ShaderType.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gl/shader/ShaderType.java
@@ -1,12 +1,14 @@
 package me.jellysquid.mods.sodium.client.gl.shader;
 
 import org.lwjgl.opengl.GL20C;
+import org.lwjgl.opengl.GL32C;
 
 /**
  * An enumeration over the supported OpenGL shader types.
  */
 public enum ShaderType {
     VERTEX(GL20C.GL_VERTEX_SHADER),
+    GEOMETRY(GL32C.GL_GEOMETRY_SHADER),
     FRAGMENT(GL20C.GL_FRAGMENT_SHADER);
 
     public final int id;


### PR DESCRIPTION
This fixes the pathtracing on packs such as SEUS PTGI, and should support all terrain passes (terrain, translucent, and shadow).