### PR TITLE
Add shadow view distance slider

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -13,6 +13,7 @@ import me.jellysquid.mods.sodium.client.gui.options.storage.SodiumOptionsStorage
 import me.jellysquid.mods.sodium.client.render.chunk.backends.multidraw.MultidrawChunkRenderBackend;
 import me.jellysquid.mods.sodium.client.util.UnsafeUtil;
 import net.coderbot.iris.Iris;
+import net.coderbot.iris.gui.option.IrisVideoSettings;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.options.AttackIndicator;
@@ -38,6 +39,15 @@ public class SodiumGameOptionPages {
                                 "rendered, improving frame rates.")
                         .setControl(option -> new SliderControl(option, 2, 32, 1, ControlValueFormatter.quantity("Chunks")))
                         .setBinding((options, value) -> options.viewDistance = value, options -> options.viewDistance)
+                        .setImpact(OptionImpact.HIGH)
+                        .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, vanillaOpts)
+                        .setName("Shadow View Distance")
+                        .setTooltip("The shadow view distance controls how far away terrain will be rendered in the shadow pass. Lower distances mean that less terrain will be " +
+                                "rendered, improving frame rates. This option has no effect on packs which specify a custom shadow distance.")
+                        .setControl(option -> new SliderControl(option, 2, 32, 1, ControlValueFormatter.quantity("Chunks")))
+                        .setBinding((options, value) -> IrisVideoSettings.shadowDistance = value, options -> IrisVideoSettings.shadowDistance)
                         .setImpact(OptionImpact.HIGH)
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build())

--- a/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/gui/SodiumGameOptionPages.java
@@ -14,6 +14,7 @@ import me.jellysquid.mods.sodium.client.render.chunk.backends.multidraw.Multidra
 import me.jellysquid.mods.sodium.client.util.UnsafeUtil;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.gui.option.IrisVideoSettings;
+import net.coderbot.iris.pipeline.WorldRenderingPipeline;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
 import net.minecraft.client.options.AttackIndicator;
@@ -28,6 +29,15 @@ import java.util.List;
 public class SodiumGameOptionPages {
     private static final SodiumOptionsStorage sodiumOpts = new SodiumOptionsStorage();
     private static final MinecraftOptionsStorage vanillaOpts = new MinecraftOptionsStorage();
+
+    private static boolean isShadowDistanceLimitedByPack() {
+        WorldRenderingPipeline pipeline = Iris.getPipelineManager().getPipeline();
+
+        if (pipeline != null) {
+            return pipeline.getForcedShadowRenderDistanceChunksForDisplay().isPresent();
+        }
+        return false;
+    }
 
     public static OptionPage general() {
         List<OptionGroup> groups = new ArrayList<>();
@@ -44,11 +54,13 @@ public class SodiumGameOptionPages {
                         .build())
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)
                         .setName("Shadow View Distance")
-                        .setTooltip("The shadow view distance controls how far away terrain will be rendered in the shadow pass. Lower distances mean that less terrain will be " +
-                                "rendered, improving frame rates. This option has no effect on packs which specify a custom shadow distance.")
+                        .setTooltip(isShadowDistanceLimitedByPack() ? "Your current shader pack has already set a render distance for shadows, you cannot change it." : "Allows you to change the maximum distance for shadows. " +
+                                "Terrain and entities beyond this distance will not cast shadows. " +
+                                "Lowering the shadow distance can significantly increase performance.")
                         .setControl(option -> new SliderControl(option, 2, 32, 1, ControlValueFormatter.quantity("Chunks")))
                         .setBinding((options, value) -> IrisVideoSettings.shadowDistance = value, options -> IrisVideoSettings.shadowDistance)
                         .setImpact(OptionImpact.HIGH)
+                        .setEnabled(!isShadowDistanceLimitedByPack())
                         .setFlags(OptionFlag.REQUIRES_RENDERER_RELOAD)
                         .build())
                 .add(OptionImpl.createBuilder(int.class, vanillaOpts)


### PR DESCRIPTION
This option currently isn't blocked when a pack specifies it's own distance, though there is a note about this in the tooltip. I couldn't find a way to consistently block the slider.